### PR TITLE
Feature: Use PadDataExtractor with other extractors (Selective, Random, ...)

### DIFF
--- a/miapy/data/assembler.py
+++ b/miapy/data/assembler.py
@@ -63,15 +63,16 @@ class SubjectAssembler(Assembler):
             self.subjects_ready = set(self.predictions.keys())
             self.predictions[subject_index] = self._init_new_subject(batch, to_assemble, idx)
 
-        index_expr = batch['index_expr'][idx]
-        if isinstance(index_expr, bytes):
-            # is pickled
-            index_expr = pickle.loads(index_expr)
-
         for key in to_assemble:
             data = to_assemble[key][idx]
             if transform is not None:
                 data = transform({key: data, 'batch': batch, 'batch_idx': idx})[key]
+
+            index_expr = batch['index_expr'][idx]
+            if isinstance(index_expr, bytes):
+                # is pickled
+                index_expr = pickle.loads(index_expr)
+
             self.predictions[subject_index][key][index_expr.expression] = data
 
     def _init_new_subject(self, batch, to_assemble, idx):

--- a/miapy/data/extraction/__init__.py
+++ b/miapy/data/extraction/__init__.py
@@ -3,7 +3,7 @@ from .indexing import (IndexingStrategy, SliceIndexing, VoxelWiseIndexing, Empty
 from .dataset import ParameterizableDataset
 from .extractor import (Extractor, DataExtractor, FilesExtractor, NamesExtractor, SubjectExtractor, IndexingExtractor,
                         SelectiveDataExtractor, RandomDataExtractor, ComposeExtractor,
-                        ImagePropertiesExtractor, PadPatchDataExtractor, ImageShapeExtractor)
+                        ImagePropertiesExtractor, PadDataExtractor, ImageShapeExtractor)
 from .sample import (select_indices, SubsetSequentialSampler, NonBlackSelection, SelectionStrategy, ComposeSelection,
                      SubjectSelection, WithForegroundSelection, PercentileSelection, NonConstantSelection)
 

--- a/miapy/data/extraction/extractor.py
+++ b/miapy/data/extraction/extractor.py
@@ -305,8 +305,13 @@ class PadPatchDataExtractor(Extractor):
 
         subject_index = params['subject_index']
         index_expr = params['index_expr']  # type: expr.IndexExpression
-        padded_indexing = np.asarray(index_expr.get_indexing()) + self.index_diffs
 
+        # Make sure all indexing is done with slices (Example: (16,) will be changed to (slice(16, 17, None),) which
+        # is equivalent), otherwise the following steps will be wrong; .
+        if any(isinstance(s, int) for s in index_expr.expression):
+            index_expr.set_indexing([slice(s, s + 1) if isinstance(s, int) else s for s in index_expr.expression])
+
+        padded_indexing = np.asarray(index_expr.get_indexing()) + self.index_diffs
         padded_shape = tuple((padded_indexing[:, 1] - padded_indexing[:, 0]).tolist())
 
         sub_indexing = padded_indexing.copy()

--- a/miapy/data/extraction/extractor.py
+++ b/miapy/data/extraction/extractor.py
@@ -316,9 +316,9 @@ class PadDataExtractor(Extractor):
         padded_indexing[padded_indexing < 0] = 0  # cannot slice outside the boundary
         padded_index_expr = expr.IndexExpression(padded_indexing.tolist())
 
-        params['index_expr'] = padded_index_expr
-        self.extractor.extract(reader, params, extracted)
-        params['index_expr'] = index_expr
+        padded_params = params.copy()
+        padded_params['index_expr'] = padded_index_expr
+        self.extractor.extract(reader, padded_params, extracted)
 
         for category in self.categories:
             data = extracted[category]

--- a/miapy/data/indexexpression.py
+++ b/miapy/data/indexexpression.py
@@ -30,6 +30,8 @@ class IndexExpression:
             elif isinstance(index, (tuple, list)):
                 start, stop = index
                 expr[a] = slice(start, stop)
+            elif isinstance(index, slice):
+                expr[a] = index
             else:
                 raise ValueError('Unknown type "{}" of index'.format(type(index)))
 


### PR DESCRIPTION
New PR just in case you want to use Padding of Selective / Random data.

Made some changes to the PadPatchDataExtractor:
- Works with SliceIndexing (Same changes as PR #9 )
- Renamed to PadDataExtractor
- PadDataExtractor no longer reads data on his own; Use the extractor parameter to load data with other miapy extractors (e. g. SelectiveData- or RandomDataExtractor, ...)